### PR TITLE
修复文档中Holder类的路径错误。

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ convenientBanner.setPages(
                 //.setPageTransformer(Transformer.DefaultTransformer);    集成特效之后会有白屏现象，新版已经分离，如果要集成特效的例子可以看Demo的点击响应。
 //        convenientBanner.setManualPageable(false);//设置不能手动影响
 
-public class LocalImageHolderView implements CBPageAdapter.Holder<Integer>{
+public class LocalImageHolderView implements Holder<Integer>{
     private ImageView imageView;
     @Override
     public View createView(Context context) {


### PR DESCRIPTION
至迟在2.0.1开始，Holder接口已经不属于CBPageAdapter的内部接口，所以不能用CBPageAdapter.Holder的方式创建。文档没有及时更新，会导致新人按照配置代码粘贴会有编译错误。