### PR TITLE
Update CBPageAdapter.java

### DIFF
--- a/convenientbanner/src/main/java/com/bigkoo/convenientbanner/adapter/CBPageAdapter.java
+++ b/convenientbanner/src/main/java/com/bigkoo/convenientbanner/adapter/CBPageAdapter.java
@@ -99,7 +99,10 @@ public class CBPageAdapter<T> extends PagerAdapter {
             holder.UpdateUI(container.getContext(), position, mDatas.get(position));
         return view;
     }
-
+    @Override
+    public int getItemPosition(Object object) {
+        return POSITION_NONE;
+    }
 //    public void setOnItemClickListener(View.OnClickListener onItemClickListener) {
 //        this.onItemClickListener = onItemClickListener;
 //    }


### PR DESCRIPTION
需要继承父类 getItemPosition(Object object)方法, 并且返回父类常亮 POSITION_NONE,  否则 如果集合数量不变,内容变了的话, 并不会触发 adapter的instantiateItem方法, 所以数据无法更新.